### PR TITLE
Integrate lead submission to ArcisAI Sales Agent API

### DIFF
--- a/src/pages/ContactUs/ContactUs.js
+++ b/src/pages/ContactUs/ContactUs.js
@@ -49,6 +49,7 @@ const ContactSection = () => {
   const toast = useToast();
 
   const BACKEND_URL = "https://vmukti.com/backend/api/send-email-arcis";
+  const SALES_AGENT_URL = "http://139.59.28.88:8000/api/v1/leads";
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -116,6 +117,28 @@ const ContactSection = () => {
     }
 
     setIsLoading(true);
+
+    // Send lead to ArcisAI Sales Agent (non-blocking)
+    fetch(SALES_AGENT_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-API-Key": "default-api-key" },
+      body: JSON.stringify({
+        name: formData.name,
+        email: formData.email,
+        phone: formData.countryCode + formData.phone,
+        company: formData.company,
+        source: "website_contact",
+        notes: "Customer Type: " + formData.customerType + " | Cameras For: " + formData.camerasFor + " | Quantity: " + formData.customerQuantity + " | Message: " + formData.message,
+        metadata: {
+          location: location2 + " " + formData.location,
+          customer_type: formData.customerType,
+          cameras_for: formData.camerasFor,
+          quantity: formData.customerQuantity,
+          page_url: window.location.href,
+        }
+      }),
+    }).catch(() => {});
+
 
     try {
       const response = await fetch(BACKEND_URL, {


### PR DESCRIPTION
## What this does
When someone fills out the Contact Us form on arcisai.io, the lead data is now also sent to the ArcisAI AI Sales Agent running on our server.

## How it works
- Added a non-blocking fetch call to the Sales Agent API alongside the existing vmukti.com backend
- - The sales agent automatically scores the lead and sends personalized follow-up emails
- - Follow-ups are scheduled at day 1, 3, 7, 14, and 30
- - The original form behavior is completely unchanged - this is an addition, not a replacement
## What data is sent
Name, email, phone, company, location, customer type, camera requirements, quantity, and message.

## Server
Sales Agent API: http://139.59.28.88:8000/api/v1/leads