### PR TITLE
P1: www→apex 301 canonical redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -126,6 +126,7 @@ const nextConfig = {
   // ─── Legacy URL Redirects (301) ─────────────────────────────────────────────
   async redirects() {
     return [
+      { source: '/:path*', has: [{ type: 'host', value: 'www.arcisai.io' }], destination: 'https://arcisai.io/:path*', permanent: true },
       { source: '/solutions',               destination: '/solution/edge-ai',    permanent: true },
       { source: '/about',                   destination: '/about-us',            permanent: true },
       { source: '/contact',                 destination: '/contact-us',          permanent: true },


### PR DESCRIPTION
Adds a host-based 301 from www.arcisai.io to apex arcisai.io in next.config.js (canonical consistency). Config-only; verified build on dev.